### PR TITLE
add support for isascii for Python 3.6.x, fixing #6

### DIFF
--- a/scripts/create_hf_dataset.py
+++ b/scripts/create_hf_dataset.py
@@ -139,7 +139,7 @@ class DatasetCreator:
                         skip_colon = False
                         continue
                     # keep latin chars together in cases of code switching
-                    if chunk.isascii():
+                    if isascii(chunk):
                         tokens.append(chunk.strip().rstrip(']'))
                         labels.append(label)
                     else:
@@ -274,6 +274,14 @@ class DatasetCreator:
         ]:
             if ds:
                 ds.save_to_disk(output_prefix+suf)
+
+
+def isascii(s):
+    try:
+        return s.isascii()
+    except AttributeError:
+        return all([ord(c) < 128 for c in s])
+
 
 def main():
     parser = argparse.ArgumentParser(description="Create huggingface datasets from MASSIVE")


### PR DESCRIPTION
*Issue #6 

*Description of changes:*

A function
```python
def isascii(s):
    try:
        return s.isascii()
    except AttributeError:
        return all([ord(c) < 128 for c in s])
```
is added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
