### PR TITLE
fixes for validation engine and for using torchrun

### DIFF
--- a/scripts/hpo.py
+++ b/scripts/hpo.py
@@ -17,6 +17,7 @@ limitations under the License.
 import argparse
 import datetime
 import logging
+import os
 import sys
 
 import datasets
@@ -50,6 +51,8 @@ def main():
     trainer_args = MASSIVETrainingArguments(**conf.get('train_val.trainer_args'))
     if args.local_rank:
         trainer_args.local_rank = int(args.local_rank)
+    elif os.getenv('LOCAL_RANK'):
+        trainer_args.local_rank = int(os.environ['LOCAL_RANK'])
 
     # Setup logging
     logging.basicConfig(

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -17,6 +17,7 @@ limitations under the License.
 import argparse
 import datetime
 import logging
+import os
 import pprint
 import sys
 import time
@@ -53,6 +54,8 @@ def main():
     trainer_args = MASSIVETrainingArguments(**conf.get('test.trainer_args'))
     if args.local_rank:
         trainer_args.local_rank = int(args.local_rank)
+    elif os.getenv('LOCAL_RANK'):
+        trainer_args.local_rank = int(os.environ['LOCAL_RANK'])
 
     # Setup logging
     logging.basicConfig(

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -17,6 +17,7 @@ limitations under the License.
 import argparse
 import datetime
 import logging
+import os
 import sys
 
 import datasets
@@ -49,6 +50,8 @@ def main():
     trainer_args = MASSIVETrainingArguments(**conf.get('train_val.trainer_args'))
     if args.local_rank:
         trainer_args.local_rank = int(args.local_rank)
+    elif os.getenv('LOCAL_RANK'):
+        trainer_args.local_rank = int(os.environ['LOCAL_RANK'])
 
     # Setup logging
     logging.basicConfig(

--- a/src/massive/utils/training_utils.py
+++ b/src/massive/utils/training_utils.py
@@ -470,6 +470,11 @@ def eval_preds(pred_intents=None, lab_intents=None, pred_slots=None, lab_slots=N
             if type(pred) == list:
                 pred = pred[:len(lab)] + [pad]*(len(lab) - len(pred))
 
+            # Fix for Issue 21 -- subwords after the first one from a word should be ignored
+            for i, x in enumerate(lab):
+                if x == -100:
+                    pred[i] = -100
+
             # convert to BIO
             bio_slot_labels.append(
                 convert_to_bio(lab, outside=labels_ignore, labels_merge=labels_merge)


### PR DESCRIPTION
**Issue https://github.com/alexa/massive/issues/21**

*Description of changes:*
There are two fixes given:
1. Code was added to the `eval_preds` function in `training_utils.py` per the suggestion of @bozheng-hit .With the current `main` branch, the validation engine is not functioning correctly, because subwords after the first subword are being handled by the `convert_to_bio` function. Instead, we want to merge/ignore the subsequent subwords and use only the prediction from the first subword. This change sets subsequent subwords to -100.
2. The train, test, and HPO scripts were modified to accept environmental variables for local_rank, allowing them to support `torchrun`.

I tested the changes with the xlmr_base example configs, both with `train.py` and `test.py`.

Once these changes are approved, I'll update the README. Thanks.