### PR TITLE
Fix path concatenation bug in create_hf_dataset.py

### DIFF
--- a/scripts/create_hf_dataset.py
+++ b/scripts/create_hf_dataset.py
@@ -267,7 +267,8 @@ class DatasetCreator:
         :type output_prefix: str
         """
 
-        with open(output_prefix+'.intents', "w") as i, open(output_prefix+'.slots', "w") as s:
+        with open(os.path.join(output_prefix, '.intents'), "w") as i,\
+             open(os.path.join(output_prefix, '.slots'), "w") as s:
             # swap the keys and vals to use the index as key and slot as val
             json.dump({v: k for k, v in self.intent_dict.items()}, i)
             json.dump({v: k for k, v in self.slot_dict.items()}, s)
@@ -286,7 +287,7 @@ class DatasetCreator:
             (self.hidden_eval, '.mmnlu22')
         ]:
             if ds:
-                ds.save_to_disk(output_prefix+suf)
+                ds.save_to_disk(os.path.join(output_prefix, suf))
 
 
 def isascii(s):


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* 
In the current `create_hf_dataset.py` file, the argument `--out-prefix` needs to have a `/` at the end.

For example on running the script as follows: 
```
python scripts/create_hf_dataset.py -d /path/to/jsonl/files -o /output/path/and/prefix
```
will generate the files as follows: `/output/path/and/prefix.dev`, `/output/path/and/prefix.train` and so on instead of the expected `/output/path/and/prefix/.dev`, `/output/path/and/prefix/.train` ...

So I have modified the code to join paths using `os.path.join` instead of simple string concatenation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
